### PR TITLE
Fix Error warning Notice: Undefined variable: paymentPlans for non el…

### DIFF
--- a/Model/Resolver/AlmaFeePlans.php
+++ b/Model/Resolver/AlmaFeePlans.php
@@ -39,6 +39,7 @@ class AlmaFeePlans
     public function getPlans($maskedQuoteId) {
 
         $feePlans = $this->getFeePlans($maskedQuoteId);
+        $paymentPlans = [];
         foreach ($feePlans as $key=> $plan){
             $planEligibility = $plan->getEligibility();
             if(!$planEligibility->isEligible()){


### PR DESCRIPTION
…igible carts

 Error : 
"debugMessage": "Notice: Undefined variable: paymentPlans in /var/www/vendor/alma/alma-monthlypayments-magento2-graph-ql/Model/Resolver/AlmaFeePlans.php on line 71",

Scenario : create a cart with a price lower than any of the eligiblity condition of alma methods

Expected behavior : get empty eligibility list
Current behavior : Notice error of undefined variable